### PR TITLE
Fixes noodle usage as node.js module by specifying the proper require string

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ You may specify a port number as an argument
 Noodle as a node module
 -----------------------
 
-If you are interested in the node module just require it and check out the 
-[noodle api](http://noodlejs.com/reference/#noodle-as-node-module)  
+If you are interested in the node module just run ```npm install noodlejs```,
+require it and check out the [noodle api](http://noodlejs.com/reference/#noodle-as-node-module)  
 
 ```javascript
-var noodle = require('noodle');
+var noodle = require('noodlejs/lib/noodle');
 
 noodle.query({
   url:      'https://github.com/explore',

--- a/lib/noodle.js
+++ b/lib/noodle.js
@@ -211,7 +211,7 @@ exports.events = new events.EventEmitter();
 // json representation at lib/config.json
 // ------------------------------------------------------------
 
-exports.config = JSON.parse(fs.readFileSync('lib/config.json'));
+exports.config = JSON.parse(fs.readFileSync(__dirname +'/config.json'));
 
 // ------------------------------------------------------------
 // Accepts a full or part config object an extends it over
@@ -348,7 +348,7 @@ function serialize (obj) {
 
 // Initialize supported document types
 
-fs.readdirSync('lib/types/').forEach(function (file) {
+fs.readdirSync(__dirname + '/types/').forEach(function (file) {
   file = file.substr(0, file.lastIndexOf('.'));
   exports[file] = require('./types/' + file);
   exports[file]._init(exports);


### PR DESCRIPTION
Fixes noodle usage as node.js module by specifying the proper require string and sets the full path (__dirname) for files that are opened by noodle.js.

It should fix issue 93: https://github.com/dharmafly/noodle/issues/93

Cheers
.paulolc
