### PR TITLE
request header should send content type and length

### DIFF
--- a/lib/noodle.js
+++ b/lib/noodle.js
@@ -126,6 +126,10 @@ exports.fetch = function (url, query) {
   if (query.post) {
     requestOptions.method = 'POST';
     requestOptions.body   = serialize(query.post);
+    requestOptions.headers = _.extend(requestOptions.headers, {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': requestOptions.body.length
+    });
     query.cache           = false;
   }
 


### PR DESCRIPTION
When I make a post request to a site it does not work correctly because we are not treating the post request properly. I added the content-type (form) and content-length request headers for post requests. This fixes my problem and I thought it might fix some others problems too.