### PR TITLE
optionally allow request (both GET and POST) to extend any/all header fields

### DIFF
--- a/lib/noodle.js
+++ b/lib/noodle.js
@@ -118,7 +118,7 @@ exports.fetch = function (url, query) {
         headers: {'user-agent': exports.config.userAgent}
       };
 
-  if (query.proxy) {
+  if (query && query.proxy) {
     requestOptions.proxy = query.proxy;
   }
 

--- a/lib/noodle.js
+++ b/lib/noodle.js
@@ -110,7 +110,7 @@ function handleQueryMap (query, deferred, i) {
 // process the document.
 // ------------------------------------------------------------
 
-exports.fetch = function (url, query, extendedHeaders) {
+exports.fetch = function (url, query) {
   var deferred       = q.defer(),
       requestOptions = {
         method: 'GET',
@@ -131,10 +131,6 @@ exports.fetch = function (url, query, extendedHeaders) {
       'Content-Length': requestOptions.body.length
     });
     query.cache           = false;
-  }
-
-  if (extendedHeaders) {
-    _.extend(requestOptions.headers, extendedHeaders);
   }
 
   // (!) This aspect should be revised.

--- a/lib/noodle.js
+++ b/lib/noodle.js
@@ -110,7 +110,7 @@ function handleQueryMap (query, deferred, i) {
 // process the document.
 // ------------------------------------------------------------
 
-exports.fetch = function (url, query) {
+exports.fetch = function (url, query, extendedHeaders) {
   var deferred       = q.defer(),
       requestOptions = {
         method: 'GET',
@@ -131,6 +131,10 @@ exports.fetch = function (url, query) {
       'Content-Length': requestOptions.body.length
     });
     query.cache           = false;
+  }
+
+  if (extendedHeaders) {
+    _.extend(requestOptions.headers, extendedHeaders);
   }
 
   // (!) This aspect should be revised.

--- a/lib/noodle.js
+++ b/lib/noodle.js
@@ -118,7 +118,7 @@ exports.fetch = function (url, query, extendedHeaders) {
         headers: {'user-agent': exports.config.userAgent}
       };
 
-  if (query && query.proxy) {
+  if (query.proxy) {
     requestOptions.proxy = query.proxy;
   }
 


### PR DESCRIPTION
I need this personally to set some GET headers for a scraping job where the referrer header matters to scrape the right data on the next pagination page, but I can imagine others wanting control over
`x-whatever` headers per-request.