### PR TITLE
Add parameters to cheerio init

### DIFF
--- a/lib/types/html.js
+++ b/lib/types/html.js
@@ -27,7 +27,7 @@ function select (body, query) {
   var deferred = q.defer(),
       extract  = query.extract || 'text',
       selector = query.selector,
-      page     = cheerio.load(body),
+      page     = cheerio.load(body, { lowerCaseTags: true, lowerCaseAttributeNames: true }),
       selected = page(selector),
       results  = [];
 


### PR DESCRIPTION
Adding lowerCaseTags and lowerCaseAttributeNames to cheerio initialization makes the parser case insensitive, so the cheerio can parse html documents poorly written, with mixed case for tags and attributes.

Without this patch, at the moment the parser fails to extract from a html code like this:

```html
<A class="tab" HREF="somelink.html" >blah blah</A>
```
 even if I specify the selector and extractor with the same case:
```javascript
{
  "type": "html",
  "selector": "A.tab",
  "extract": ["HREF", "text"]
}
```